### PR TITLE
Selected group lighting

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-	<title>React App</title>
+	<title>Reddit Explorer</title>
 </head>
 
 <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -364,15 +364,6 @@ export default function App() {
               }}
             />
             <div>
-              <label htmlFor="numClusters" ># Clusters: </label>
-              <select name="numClusters" id="numClusters"
-                      onChange={(event) => setClusterIndex(clusterCounts.indexOf(+event.target.value))}
-                      value={clusterCounts[clusterIndex]}>
-                {clusterCounts.map(clusterCount => <option value={clusterCount} key={clusterCount}>{clusterCount}</option>)}
-              </select>
-            </div>
-
-            <div>
               <label htmlFor="pointCount" ># Points: </label>
               <select name="pointCount" id="pointCount" onChange={(event) => {
                 //setSelectedIds([]);
@@ -380,6 +371,14 @@ export default function App() {
               }}
                       value={pointCount}>
                 {pointCounts.map(pointCount => <option value={pointCount} key = {pointCount}>{pointCount}</option>)}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="numClusters" ># Clusters: </label>
+              <select name="numClusters" id="numClusters"
+                      onChange={(event) => setClusterIndex(clusterCounts.indexOf(+event.target.value))}
+                      value={clusterCounts[clusterIndex]}>
+                {clusterCounts.map(clusterCount => <option value={clusterCount} key={clusterCount}>{clusterCount}</option>)}
               </select>
             </div>
             <div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -343,134 +343,137 @@ export default function App() {
                 onChange={(event) => setMultiSelect(event.target.checked)}
               />
             </form>
+            <br />
+            <label htmlFor="nsfwSlider">
+              {" "}
+              Max % NSFW Threads: {maxPercentNSFW}
+            </label>
+            <input
+              id="nsfwSlider"
+              type="range"
+              min={0}
+              max={100}
+              step={0.1}
+              value={maxPercentNSFW}
+              onChange={(event) => {
+                setMaxPercentNSFW(+event.target.value);
+                selectedPoints.filter(point => point.percentNsfw < +event.target.value)
+                setSelectedPoints(selectedPoints);
+                //}
+              }}
+            />
             <div>
-                <label htmlFor="resolutionSlider">
-                  {" "}
-                  Point Resolution: {pointResolution}
-                </label>
-                <input
-                  id="resolutionSlider"
-                  type="range"
-                  min="1"
-                  max={MAX_POINT_RES}
-                  value={pointResolution}
-                  onChange={(event) => setPointResolution(+event.target.value)}
-                  step="1"
-                />
-                <br />
-                <label htmlFor="nsfwSlider">
-                  {" "}
-                  Max % NSFW Threads: {maxPercentNSFW}
-                </label>
-                <input
-                  id="nsfwSlider"
-                  type="range"
-                  min={0}
-                  max={100}
-                  step={0.1}
-                  value={maxPercentNSFW}
-                  onChange={(event) => {
-                    setMaxPercentNSFW(+event.target.value);
-                    selectedPoints.filter(point => point.percentNsfw < +event.target.value)
-                    setSelectedPoints(selectedPoints);
-                    //}
-                  }}
-                />
-                <br />
-                <label htmlFor="usePostProcessing">
-                  Enable Post FX:
-                </label>
-                <input
-                  id="usePostProcessing"
-                  type="checkbox"
-                  checked={usePostProcessing}
-                  onChange={(event) => setUsePostProcessing(event.target.checked)}
-                />
-                <br />
-                <label htmlFor="usePerPointLighting">
-                  Per Point Lighting:
-                </label>
-                <input
-                  id="usePerPointLighting"
-                  type="checkbox"
-                  checked={usePerPointLighting}
-                  onChange={(event) => setUsePerPointLighting(event.target.checked)}
-                />
-                <br />
-                <label htmlFor="showClusterHulls">
-                  Show Cluster Hulls:
-                </label>
-                <input
-                  id="showClusterHulls"
-                  type="checkbox"
-                  checked={showClusterHulls}
-                  onChange={(event) => setShowClusterHulls(event.target.checked)}
-                />
-              </div>
-              <div>
-                <label htmlFor="numClusters" ># Clusters: </label>
-                <select name="numClusters" id="numClusters"
-                        onChange={(event) => setClusterIndex(clusterCounts.indexOf(+event.target.value))}
-                        value={clusterCounts[clusterIndex]}>
-                  {clusterCounts.map(clusterCount => <option value={clusterCount} key={clusterCount}>{clusterCount}</option>)}
-                </select>
-              </div>
-              <div>
-                <label htmlFor="dataSet" ># Data Set: </label>
-                <select name="dataSet" id="dataSet"
-                        onChange={(event) => setDataSet(dataSets[event.target.value as keyof dataSetList])}
-                        value={dataSets[dataSet]}>
-                  {Object.keys(dataSets).map(dataSet => <option value={dataSet} key={dataSet}>{dataSet}</option>)}
-                </select>
-              </div>
-              <div>
-                <label htmlFor="pointCount" ># Points: </label>
-                <select name="pointCount" id="pointCount" onChange={(event) => {
-                  //setSelectedIds([]);
-                  setPointCount(+event.target.value);
-                }}
-                value={pointCount}>
-                  {pointCounts.map(pointCount => <option value={pointCount} key = {pointCount}>{pointCount}</option>)}
-                </select>
-              </div>
-              <br />
-              <label htmlFor="viewDistance">
-                {" "}
-                View Distance: {viewDistance}
-              </label>
-              <input
-                id="voxelResSlider"
-                type="range"
-                min={MIN_VIEW_DISTANCE}
-                max={MAX_VIEW_DISTANCE}
-                value={viewDistance}
-                onChange={(event) => setViewDistance(+event.target.value)}
-                step="1"
-              />
-              <br />
-              <label htmlFor="voxelResSlider">
-                {" "}
-                Voxel Resolution: {voxelResolution}
-              </label>
-              <input
-                id="voxelResSlider"
-                type="range"
-                min={1}
-                max={MAX_VOXEL_RES}
-                value={voxelResolution}
-                onChange={(event) => setVoxelResolution(+event.target.value)}
-                step="1"
-              />
-              <br />
-              <label htmlFor="debugVoxels">
-                Show Voxel Debug:
-              </label>
-              <input
-                id="debugVoxels"
-                type="checkbox"
-                checked={debugVoxels}
-                onChange={(event) => setDebugVoxels(event.target.checked)}
-              />
+              <label htmlFor="numClusters" ># Clusters: </label>
+              <select name="numClusters" id="numClusters"
+                      onChange={(event) => setClusterIndex(clusterCounts.indexOf(+event.target.value))}
+                      value={clusterCounts[clusterIndex]}>
+                {clusterCounts.map(clusterCount => <option value={clusterCount} key={clusterCount}>{clusterCount}</option>)}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="dataSet" >Data Set: </label>
+              <select name="dataSet" id="dataSet"
+                      onChange={(event) => setDataSet(dataSets[event.target.value as keyof dataSetList])}
+                      value={dataSets[dataSet]}>
+                {Object.keys(dataSets).map(dataSet => <option value={dataSet} key={dataSet}>{dataSet}</option>)}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="pointCount" ># Points: </label>
+              <select name="pointCount" id="pointCount" onChange={(event) => {
+                //setSelectedIds([]);
+                setPointCount(+event.target.value);
+              }}
+                      value={pointCount}>
+                {pointCounts.map(pointCount => <option value={pointCount} key = {pointCount}>{pointCount}</option>)}
+              </select>
+            </div>
+            <label htmlFor="showClusterHulls">
+              Show Cluster Hulls:
+            </label>
+            <input
+              id="showClusterHulls"
+              type="checkbox"
+              checked={showClusterHulls}
+              onChange={(event) => setShowClusterHulls(event.target.checked)}
+            />
+
+            <br/>
+            <br/>
+            <h4>Performance Options</h4>
+            <label htmlFor="resolutionSlider">
+              {" "}
+              Point Resolution: {pointResolution}
+            </label>
+            <input
+              id="resolutionSlider"
+              type="range"
+              min="1"
+              max={MAX_POINT_RES}
+              value={pointResolution}
+              onChange={(event) => setPointResolution(+event.target.value)}
+              step="1"
+            />
+            <br />
+            <label htmlFor="usePostProcessing">
+              Enable Post FX:
+            </label>
+            <input
+              id="usePostProcessing"
+              type="checkbox"
+              checked={usePostProcessing}
+              onChange={(event) => setUsePostProcessing(event.target.checked)}
+            />
+            <br />
+            <label htmlFor="usePerPointLighting">
+              Per Point Lighting:
+            </label>
+            <input
+              id="usePerPointLighting"
+              type="checkbox"
+              checked={usePerPointLighting}
+              onChange={(event) => setUsePerPointLighting(event.target.checked)}
+            />
+            <br />
+            <label htmlFor="viewDistance">
+              {" "}
+              View Distance: {viewDistance}
+            </label>
+
+            <h4>Advanced / Debug</h4>
+            <input
+              id="voxelResSlider"
+              type="range"
+              min={MIN_VIEW_DISTANCE}
+              max={MAX_VIEW_DISTANCE}
+              value={viewDistance}
+              onChange={(event) => setViewDistance(+event.target.value)}
+              step="1"
+            />
+            <br />
+            <label htmlFor="voxelResSlider">
+              {" "}
+              Voxel Resolution: {voxelResolution}
+            </label>
+            <input
+              id="voxelResSlider"
+              type="range"
+              min={1}
+              max={MAX_VOXEL_RES}
+              value={voxelResolution}
+              onChange={(event) => setVoxelResolution(+event.target.value)}
+              step="1"
+            />
+            <br />
+            <label htmlFor="debugVoxels">
+              Show Voxel Debug:
+            </label>
+            <input
+              id="debugVoxels"
+              type="checkbox"
+              checked={debugVoxels}
+              onChange={(event) => setDebugVoxels(event.target.checked)}
+            />
             {/*glContext && <DebugStats gl={glContext}/> */}
           </>
         )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import {
   POINT_RADIUS,
   MAX_VOXEL_RES,
   MIN_VIEW_DISTANCE,
-  MAX_VIEW_DISTANCE
+  MAX_VIEW_DISTANCE, MOBILE_THRESHOLD_WIDTH
 } from "./constants";
 import {Stats} from "./ThreePointVis/Stats";
 import {Camera, Canvas} from "react-three-fiber";
@@ -69,7 +69,7 @@ const getMesh = (group: Group | Object3D): Mesh => {
   return new Mesh(geometry, material);
 };
 
-export const pointCounts = [10000, 25000, 50000, 100000, 250000, 500000, 1000000];
+export const pointCounts = [10000, 25000, 50000, 100000, 250000, 500000];
 
 export default function App() {
   const [redditData, setRedditData] = React.useState<Point[]>([]);
@@ -86,6 +86,7 @@ export default function App() {
   );
   const [maxPercentNSFW, setMaxPercentNSFW] = React.useState(10);
   const [usePostProcessing, setUsePostProcessing] = React.useState(true);
+  const [usePerPointLighting, setUsePerPointLighting] = React.useState(window.innerWidth > MOBILE_THRESHOLD_WIDTH);
   const [showClusterHulls, setShowClusterHulls] = React.useState(false);
   const [dataSet, setDataSet] = React.useState<string>(dataSets[Object.keys(dataSets)[0]]);
   const [voxelResolution, setVoxelResolution] = React.useState(getAutoVoxelResolution(pointCount));
@@ -276,6 +277,7 @@ export default function App() {
                     pointResolution={pointResolution}
                     voxelResolution={voxelResolution}
                     debugVoxels={debugVoxels}
+                    usePerPointLighting={usePerPointLighting}
                   />
                 )
             </Canvas>
@@ -383,6 +385,16 @@ export default function App() {
                   type="checkbox"
                   checked={usePostProcessing}
                   onChange={(event) => setUsePostProcessing(event.target.checked)}
+                />
+                <br />
+                <label htmlFor="usePerPointLighting">
+                  Per Point Lighting:
+                </label>
+                <input
+                  id="usePerPointLighting"
+                  type="checkbox"
+                  checked={usePerPointLighting}
+                  onChange={(event) => setUsePerPointLighting(event.target.checked)}
                 />
                 <br />
                 <label htmlFor="showClusterHulls">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,9 +74,9 @@ export const pointCounts = [10000, 25000, 50000, 100000, 250000, 500000];
 export default function App() {
   const [redditData, setRedditData] = React.useState<Point[]>([]);
   const [clusters, setClusters] = React.useState<Cluster[]>([]);
-  const [clusterIndex, setClusterIndex] = React.useState<number>(0);
-  const [pointCount, setPointCount] = React.useState<number>(25000);
   const [clusterCounts, setClusterCounts] = React.useState<number[]>([]);
+  const [clusterIndex, setClusterIndex] = React.useState<number>(3); // TODO remove hard coding
+  const [pointCount, setPointCount] = React.useState<number>(25000);
   const [selectedPoints, setSelectedPoints] = React.useState<Point[]>([]);
   const [searchTerm, setSearchTerm] = React.useState("");
   const [showControls, setShowControls] = React.useState(true);
@@ -176,8 +176,9 @@ export default function App() {
   },[viewDistance, camera] )
 
   const search = () => {
+    const cleanedSearchTerm = searchTerm.toLowerCase().trim();
     redditData.forEach((point) => {
-      if (point.include && point.subreddit.toLowerCase() === searchTerm.toLowerCase()) {
+      if (point.include && point.subreddit.toLowerCase() === cleanedSearchTerm) {
         if(multiSelect) {
           const newSelectedPoints = [...selectedPoints];
           newSelectedPoints.push(point);
@@ -370,14 +371,7 @@ export default function App() {
                 {clusterCounts.map(clusterCount => <option value={clusterCount} key={clusterCount}>{clusterCount}</option>)}
               </select>
             </div>
-            <div>
-              <label htmlFor="dataSet" >Data Set: </label>
-              <select name="dataSet" id="dataSet"
-                      onChange={(event) => setDataSet(dataSets[event.target.value as keyof dataSetList])}
-                      value={dataSets[dataSet]}>
-                {Object.keys(dataSets).map(dataSet => <option value={dataSet} key={dataSet}>{dataSet}</option>)}
-              </select>
-            </div>
+
             <div>
               <label htmlFor="pointCount" ># Points: </label>
               <select name="pointCount" id="pointCount" onChange={(event) => {
@@ -386,6 +380,14 @@ export default function App() {
               }}
                       value={pointCount}>
                 {pointCounts.map(pointCount => <option value={pointCount} key = {pointCount}>{pointCount}</option>)}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="dataSet" >Data Set: </label>
+              <select name="dataSet" id="dataSet"
+                      onChange={(event) => setDataSet(dataSets[event.target.value as keyof dataSetList])}
+                      value={dataSets[dataSet]}>
+                {Object.keys(dataSets).map(dataSet => <option value={dataSet} key={dataSet}>{dataSet}</option>)}
               </select>
             </div>
             <label htmlFor="showClusterHulls">
@@ -401,20 +403,6 @@ export default function App() {
             <br/>
             <br/>
             <h4>Performance Options</h4>
-            <label htmlFor="resolutionSlider">
-              {" "}
-              Point Resolution: {pointResolution}
-            </label>
-            <input
-              id="resolutionSlider"
-              type="range"
-              min="1"
-              max={MAX_POINT_RES}
-              value={pointResolution}
-              onChange={(event) => setPointResolution(+event.target.value)}
-              step="1"
-            />
-            <br />
             <label htmlFor="usePostProcessing">
               Enable Post FX:
             </label>
@@ -434,13 +422,25 @@ export default function App() {
               checked={usePerPointLighting}
               onChange={(event) => setUsePerPointLighting(event.target.checked)}
             />
+            <br/>
+            <label htmlFor="resolutionSlider">
+              {" "}
+              Point Resolution: {pointResolution}
+            </label>
+            <input
+              id="resolutionSlider"
+              type="range"
+              min="1"
+              max={MAX_POINT_RES}
+              value={pointResolution}
+              onChange={(event) => setPointResolution(+event.target.value)}
+              step="1"
+            />
             <br />
             <label htmlFor="viewDistance">
               {" "}
               View Distance: {viewDistance}
             </label>
-
-            <h4>Advanced / Debug</h4>
             <input
               id="voxelResSlider"
               type="range"
@@ -450,7 +450,8 @@ export default function App() {
               onChange={(event) => setViewDistance(+event.target.value)}
               step="1"
             />
-            <br />
+
+            <h4>Advanced / Debug</h4>
             <label htmlFor="voxelResSlider">
               {" "}
               Voxel Resolution: {voxelResolution}

--- a/src/ThreePointVis/Controls.tsx
+++ b/src/ThreePointVis/Controls.tsx
@@ -22,6 +22,14 @@ const ANIMATION_SPEED = 5;
 
 const origin = new THREE.Vector3(0, 0, 0);
 
+const hasCameraChanged = (prevProps: ControlsProps, nextProps: ControlsProps): boolean => {
+  return prevProps.distance === nextProps.distance
+    && prevProps.position && nextProps.position
+    && prevProps.target && nextProps.target
+    && prevProps.position.equals(nextProps.position)
+    && prevProps.target.equals(nextProps.target) || false
+}
+
 export const Controls = memo((props: ControlsProps) => {
   const { target, position, distance } = props;
 
@@ -129,4 +137,4 @@ export const Controls = memo((props: ControlsProps) => {
       enableDamping
     />
   );
-});
+}, hasCameraChanged);

--- a/src/ThreePointVis/Effects.tsx
+++ b/src/ThreePointVis/Effects.tsx
@@ -32,8 +32,8 @@ export function Effects(props: EffectsProps) {
 
   const unrealBloom = {
     resolution: aspect,
-    strength: 0.4,
-    radius: 0.01,
+    strength: 0.3,
+    radius: 0.02,
     threshold: 0.19
   };
 

--- a/src/ThreePointVis/ThreePointVis.tsx
+++ b/src/ThreePointVis/ThreePointVis.tsx
@@ -25,10 +25,12 @@ interface ThreePointVisProps {
   pointResolution: number;
   voxelResolution: number;
   debugVoxels?: boolean;
+  usePerPointLighting?: boolean;
 }
 
 export const ThreePointVis = memo((props: ThreePointVisProps) => {
-  const { data, selectedPoints, clusters, onSelect, pointResolution, voxelResolution, debugVoxels } = props;
+  const { data, selectedPoints, clusters, onSelect, pointResolution,
+    voxelResolution, debugVoxels, usePerPointLighting } = props;
 
   const selectedPointVectors = selectedPoints.map(point => new Vector3(point.x, point.y, point.z));
   const selectedBoundingSphere = new THREE.Sphere().setFromPoints(selectedPointVectors);
@@ -50,14 +52,15 @@ export const ThreePointVis = memo((props: ThreePointVisProps) => {
 
   const renderSelectedPoints = selectedPoints.map(
       function(point) {
-          return(<group
+          return(
+            <group
               key={point.id}
               position={[
                   point.x,
                   point.y,
                   point.z
               ]}
-          >
+            >
               <Text
                   message={point.subreddit}
                   x={0}
@@ -84,6 +87,7 @@ export const ThreePointVis = memo((props: ThreePointVisProps) => {
                                        transparent={true}
                                        color={SELECTED_COLOR}/>
               </mesh>
+            {usePerPointLighting &&
               <pointLight
                   distance={10 * SCALE_FACTOR}
                   position={[0, 0, 0]}
@@ -91,6 +95,7 @@ export const ThreePointVis = memo((props: ThreePointVisProps) => {
                   decay={1}
                   color={SELECTED_COLOR}
               />
+            }
           </group>)
       }
 
@@ -124,7 +129,18 @@ export const ThreePointVis = memo((props: ThreePointVisProps) => {
           />}
 
         {selectedPoints.length > 0 && (
-            renderSelectedPoints
+          <>
+            {renderSelectedPoints}
+            {!usePerPointLighting &&
+            <pointLight
+                distance={10 + selectedBoundingSphere.radius}
+                position={selectedBoundingSphere.center}
+                intensity={1.9}
+                decay={1}
+                color={SELECTED_COLOR}
+            />
+            }
+          </>
         )}
       </>)
 });

--- a/src/ThreePointVis/ThreePointVis.tsx
+++ b/src/ThreePointVis/ThreePointVis.tsx
@@ -7,7 +7,7 @@ import { Cluster, Point } from "../App";
 import { useWindowSize} from "../ViewportHooks"
 import {VoxelInstancedPoints} from "./VoxelInstancedPoints";
 import {ClusterHulls} from "./ClusterHulls";
-import {MAX_POINT_RES, POINT_RADIUS, SCALE_FACTOR, SELECTED_COLOR} from "../constants";
+import {MAX_POINT_RES, MOBILE_THRESHOLD_WIDTH, POINT_RADIUS, SCALE_FACTOR, SELECTED_COLOR} from "../constants";
 import {memo, useMemo} from "react";
 import {Color, Vector3} from "three";
 
@@ -66,7 +66,7 @@ export const ThreePointVis = memo((props: ThreePointVisProps) => {
                   x={0}
                   y={0}
                   z={0}
-                  position={width < 500 ? Position.BOTTOM : Position.RIGHT}
+                  position={width < MOBILE_THRESHOLD_WIDTH ? Position.BOTTOM : Position.RIGHT}
               />
               <mesh renderOrder={2}>
                   <sphereBufferGeometry

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,9 @@ export const dataSets: dataSetList = {
   New25: "new_0.25"
 }
 
+// Threshold for auto disabling expensive graphical effects
+export const MOBILE_THRESHOLD_WIDTH = 950; // A little under half 1080p
+
 //https://coolors.co/263b3b-0b195e-bc3c00-773b08-541818-340534-0e2412-3b0c1a-790579-0d620b
 export const clusterColors = [
   "#263b3b",

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -15,6 +15,11 @@ div {
   width: 100vw;
   background-color: #000;
 
+  h4 {
+    margin-bottom: 0.5em;
+    margin-block-end: 0.5em;
+  }
+
   .vis-container {
     position: absolute;
     top: 0;


### PR DESCRIPTION
Massive performance increase at many selected points, since forward renderer does one shading pass per light

Per point (~15fps):
![image](https://user-images.githubusercontent.com/69126861/94352429-b40f0e00-0019-11eb-93b3-7af89506beb4.png

Off (~90fps):
![image](https://user-images.githubusercontent.com/69126861/94352437-ca1cce80-0019-11eb-93f7-d5ea07e07547.png)

Per point (~12fps):
![image](https://user-images.githubusercontent.com/69126861/94352443-dacd4480-0019-11eb-9ced-57c6c3a46737.png)

Per-group (off final ~60fps):
![image](https://user-images.githubusercontent.com/69126861/94352447-e91b6080-0019-11eb-8b75-77b0f46ef4a7.png)

Sparse Group:
Per-Point:
![image](https://user-images.githubusercontent.com/69126861/94352454-f3d5f580-0019-11eb-811b-ddd71a0eb104.png)
Per-Group:
![image](https://user-images.githubusercontent.com/69126861/94352455-f8021300-0019-11eb-8d1c-7229b954311f.png)
