### PR TITLE
Ux tweaks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,6 +84,7 @@ export default function App() {
   const pointCount = parseInt(query.get('point_count') || '0', 10) || 25000;
   const dataSet = query.get('data_set') || dataSets[Object.keys(dataSets)[0]];
   const selection = useMemo(() => (query.get('selection') || '').split(',') || [], [query]);
+  const hideUserAccounts = query.get('hideUserAccounts') === 'true';
   const { width, height } = useWindowSize();
 
   const [clusterIndex, setClusterIndex] = React.useState<number>(3); // TODO remove hard coding
@@ -98,7 +99,6 @@ export default function App() {
   const [useAntiAliasing, setUseAntiAliasing] = React.useState(isMobile);
   const [resolutionScale, setResolutionScale] = React.useState(Math.ceil(window.devicePixelRatio / 2));
   const [usePerPointLighting, setUsePerPointLighting] = React.useState(isMobile);
-  const [hideUserAccounts, setHideUserAccounts] = React.useState(false);
   const [showClusterHulls, setShowClusterHulls] = React.useState(false);
   const [voxelResolution, setVoxelResolution] = React.useState(getAutoVoxelResolution(pointCount));
   const [debugVoxels, setDebugVoxels] = React.useState(false);
@@ -400,7 +400,7 @@ export default function App() {
                 id="hideUserAccounts"
                 type="checkbox"
                 checked={hideUserAccounts}
-                onChange={(event) => setHideUserAccounts(event.target.checked)}
+                onChange={(event) => setParam('hideUserAccounts', event.target.checked ? 'true' : 'false')}
               />
               <br />
               <br />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,19 +159,19 @@ export default function App() {
     }
   }, [viewDistance, camera]);
 
-  const selectOrDeselectPoint = (index: number, isMultiSelect: boolean) => {
+  const selectOrDeselectPoint = (id: number, isMultiSelect: boolean) => {
     const selectedIds = selectedPoints.map((point) => point.id);
     if (isMultiSelect) {
-      if (!selectedIds.includes(index)) {
+      if (!selectedIds.includes(id)) {
         const newSelection = [...selection];
-        newSelection.push(redditData[index].subreddit);
+        newSelection.push(redditData[id].subreddit);
         setParam('selection', newSelection.join(','));
       } else {
-        const newSelectedPoints = [...selectedPoints].filter((point) => point.id !== index);
+        const newSelectedPoints = [...selectedPoints].filter((point) => point.id !== id);
         setParam('selection', newSelectedPoints.map((p) => p.subreddit).join(','));
       }
-    } else if (selectedIds.length !== 1 || selectedIds[0] !== index) {
-      setParam('selection', redditData[index].subreddit);
+    } else if (selectedIds.length !== 1 || selectedIds[0] !== id) {
+      setParam('selection', redditData[id].subreddit);
     } else {
       setParam('selection', '');
     }
@@ -322,7 +322,13 @@ export default function App() {
                     </button>
                   </div>
                   <div className="selected-points-info">
-                    {selectedPoints.map((point) => <PointInfo key={point.id} point={point} />)}
+                    {selectedPoints.map((point) => (
+                      <PointInfo
+                        key={point.id}
+                        point={point}
+                        onDeselect={() => selectOrDeselectPoint(point.id, true)}
+                      />
+                    ))}
                   </div>
                 </>
               )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,6 +100,7 @@ export default function App() {
   const [resolutionScale, setResolutionScale] = React.useState(Math.ceil(window.devicePixelRatio / 2));
   const [usePerPointLighting, setUsePerPointLighting] = React.useState(isMobile);
   const [showClusterHulls, setShowClusterHulls] = React.useState(false);
+  const [isAutoCamera, setIsAutoCamera] = React.useState(true);
   const [voxelResolution, setVoxelResolution] = React.useState(getAutoVoxelResolution(pointCount));
   const [debugVoxels, setDebugVoxels] = React.useState(false);
   const [viewDistance, setViewDistance] = React.useState(
@@ -276,6 +277,7 @@ export default function App() {
             voxelResolution={voxelResolution}
             debugVoxels={debugVoxels}
             usePerPointLighting={usePerPointLighting}
+            isAutoCamera={isAutoCamera}
           />
           )
         </Canvas>
@@ -418,6 +420,16 @@ export default function App() {
                 type="checkbox"
                 checked={showClusterHulls}
                 onChange={(event) => setShowClusterHulls(event.target.checked)}
+              />
+              <br />
+              <label htmlFor="isAutoCamera">
+                Auto Camera:
+              </label>
+              <input
+                id="isAutoCamera"
+                type="checkbox"
+                checked={isAutoCamera}
+                onChange={(event) => setIsAutoCamera(event.target.checked)}
               />
             </TabPanel>
 

--- a/src/PointInfo/PointInfo.scss
+++ b/src/PointInfo/PointInfo.scss
@@ -10,5 +10,11 @@
     display: flex;
     justify-content: space-between;
   }
+
+  .deselect-button {
+    background: maroon;
+    color: white;
+    margin-left: 0.25rem;
+  }
 }
 

--- a/src/PointInfo/PointInfo.scss
+++ b/src/PointInfo/PointInfo.scss
@@ -1,14 +1,21 @@
+@import '../constants.scss';
+
 .point-info {
 
   margin: 0.5em 0;
 
   a {
-    color: rgb(69, 119, 255);
+    color: $accentColor;
   }
 
   .point-header {
     display: flex;
     justify-content: space-between;
+  }
+
+  .toggle-info-button {
+    background: $accentColor;
+    color: white;
   }
 
   .deselect-button {

--- a/src/PointInfo/PointInfo.tsx
+++ b/src/PointInfo/PointInfo.tsx
@@ -8,10 +8,11 @@ import './PointInfo.scss';
 
 interface PointsInfoProps {
   point: Point;
+  onDeselect: () => void;
 }
 
 export const PointInfo = memo((props: PointsInfoProps) => {
-  const { point } = props;
+  const { point, onDeselect } = props;
   const [showMoreInfo, setShowMoreInfo] = React.useState(false);
 
   return (
@@ -24,13 +25,22 @@ export const PointInfo = memo((props: PointsInfoProps) => {
         >
           <strong>{point.subreddit}</strong>
         </a>
-        <button
-          type="button"
-          className="toggle-info-button"
-          onClick={() => setShowMoreInfo(!showMoreInfo)}
-        >
-          {showMoreInfo ? minimizeChar : expandChar}
-        </button>
+        <div className="action-buttons">
+          <button
+            type="button"
+            className="toggle-info-button"
+            onClick={() => setShowMoreInfo(!showMoreInfo)}
+          >
+            {showMoreInfo ? minimizeChar : expandChar}
+          </button>
+          <button
+            type="button"
+            className="deselect-button"
+            onClick={() => onDeselect()}
+          >
+            x
+          </button>
+        </div>
       </div>
       {showMoreInfo && <PointDetailsSection point={point} />}
     </div>

--- a/src/ThreePointVis/Controls.tsx
+++ b/src/ThreePointVis/Controls.tsx
@@ -9,6 +9,7 @@ interface ControlsProps {
   target: THREE.Vector3 | null;
   position: THREE.Vector3 | null;
   distance: number;
+  autoTarget?: boolean;
 }
 
 extend({ OrbitControls });
@@ -29,7 +30,9 @@ const hasCameraChanged = (prevProps: ControlsProps, nextProps: ControlsProps):
     && prevProps.target.equals(nextProps.target)) || false;
 
 export const Controls = memo((props: ControlsProps) => {
-  const { target, position, distance } = props;
+  const {
+    target, position, distance, autoTarget,
+  } = props;
 
   const cameraDistance = POSITION_THRESHOLD_OFFSET + POSITION_THRESHOLD_SCALER * distance;
 
@@ -39,8 +42,8 @@ export const Controls = memo((props: ControlsProps) => {
 
   const keyPressed: { [key: string]: number } = {};
 
-  let targetAnimationComplete = false;
-  let positionAnimationComplete = false;
+  let targetAnimationComplete = !autoTarget;
+  let positionAnimationComplete = !autoTarget;
 
   const handleKeyDown = (event: KeyboardEvent) => {
     if (!keyPressed[event.key]) {

--- a/src/ThreePointVis/ThreePointVis.tsx
+++ b/src/ThreePointVis/ThreePointVis.tsx
@@ -27,12 +27,13 @@ interface ThreePointVisProps {
   voxelResolution: number;
   debugVoxels?: boolean;
   usePerPointLighting?: boolean;
+  isAutoCamera?: boolean;
 }
 
 export const ThreePointVis = memo((props: ThreePointVisProps) => {
   const {
     data, selectedPoints, clusters, onSelect, pointResolution,
-    voxelResolution, debugVoxels, usePerPointLighting,
+    voxelResolution, debugVoxels, usePerPointLighting, isAutoCamera,
   } = props;
 
   const selectedPointVectors = selectedPoints.map((point) => new Vector3(point.x, point.y, point.z));
@@ -111,7 +112,12 @@ export const ThreePointVis = memo((props: ThreePointVisProps) => {
 
   return (
     <>
-      <Controls target={cameraTarget} position={cameraPosition} distance={selectedBoundingSphere.radius} />
+      <Controls
+        target={cameraTarget}
+        position={cameraPosition}
+        distance={selectedBoundingSphere.radius}
+        autoTarget={isAutoCamera}
+      />
       <ambientLight color="#ffffff" intensity={0.1} />
       <hemisphereLight
         color="#ffffff"

--- a/src/ThreePointVis/ThreePointVis.tsx
+++ b/src/ThreePointVis/ThreePointVis.tsx
@@ -36,8 +36,10 @@ export const ThreePointVis = memo((props: ThreePointVisProps) => {
     voxelResolution, debugVoxels, usePerPointLighting, isAutoCamera,
   } = props;
 
-  const selectedPointVectors = selectedPoints.map((point) => new Vector3(point.x, point.y, point.z));
-  const selectedBoundingSphere = new THREE.Sphere().setFromPoints(selectedPointVectors);
+  const selectedPointVectors = useMemo(() =>
+    selectedPoints.map((point) => new Vector3(point.x, point.y, point.z)), [selectedPoints]);
+  const selectedBoundingSphere = useMemo(() =>
+    new THREE.Sphere().setFromPoints(selectedPointVectors), [selectedPointVectors]);
   selectedBoundingSphere.radius = Math.max(selectedBoundingSphere.radius, 1);
 
   const cameraTarget = selectedPoints.length > 0
@@ -52,7 +54,7 @@ export const ThreePointVis = memo((props: ThreePointVisProps) => {
 
   const selectedPointRes = useMemo(() => Math.min(pointResolution * 4, MAX_POINT_RES), [pointResolution]);
 
-  const renderSelectedPoints = selectedPoints.map(
+  const renderSelectedPoints = useMemo(() => selectedPoints.map(
     (point) => (
       <group
         key={point.id}
@@ -107,8 +109,7 @@ export const ThreePointVis = memo((props: ThreePointVisProps) => {
               )}
       </group>
     ),
-
-  );
+  ), [selectedPointRes, selectedPoints, usePerPointLighting, width]);
 
   return (
     <>

--- a/src/constants.scss
+++ b/src/constants.scss
@@ -1,0 +1,1 @@
+$accentColor: rgb(69, 119, 255);


### PR DESCRIPTION
1. Added hideUserAccounts to url query parameter so it is respected in sharing
2. Added deselect button to point info
3. Added a toggle to disable auto camera

Things that I bailed on (for now)

1. NSFW percent in url: I think it's safer to keep the default at least at first. The selection still will show on load, but NSFW points around it will not.
2. Show/Hide cluster hulls in URL: I think this is a user/display preference rather than part of the data set, so should not be part of the URL
3. NSFW slider debounce: I spent about a half hour on this thinking it would be easy and kept running into issues so decided it was low enough priority

![image](https://user-images.githubusercontent.com/69126861/121129792-4fc85f00-c7e2-11eb-9e0f-7478bf3b3cbc.png)
