### PR TITLE
Update VoxelInstancedPoints to update mesh on resolution update

### DIFF
--- a/src/ThreePointVis/VoxelInstancedPoints.tsx
+++ b/src/ThreePointVis/VoxelInstancedPoints.tsx
@@ -82,7 +82,7 @@ export const VoxelInstancedPoints = memo((props: VoxelInstancedPointsProps) => {
     setVoxels(newVoxels);
   }, [data, voxelResolution]);
 
-  // Set up voxels with appropriate data (only when data changes, not per frame)
+  // Set up voxels with appropriate data (only when data or point resolution changes, not per frame)
   React.useEffect(() => {
     for (let i = 0; i < voxels.length; ++i) {
       const voxel = voxels[i];
@@ -115,7 +115,7 @@ export const VoxelInstancedPoints = memo((props: VoxelInstancedPointsProps) => {
         );
       }
     }
-  }, [voxels, colorArrays, debugVoxels]);
+  }, [voxels, colorArrays, debugVoxels, pointSegments]); // include pointSegments to reset mesh
 
   return (
     <>
@@ -123,6 +123,7 @@ export const VoxelInstancedPoints = memo((props: VoxelInstancedPointsProps) => {
         ? (
           <instancedMesh
             key={`${index} ${voxel.length}`}
+            name={`mesh - voxel ${index}`}
             ref={(mesh: THREE.InstancedMesh) => meshRefs.current[index] = mesh}
             args={[
                   // TODO sort out the bugged typing here.


### PR DESCRIPTION
Previously, changing the point resolution performance option with a voxel resolution >1 would cause most views to be completely black.